### PR TITLE
WAF deployment instructions

### DIFF
--- a/docs/approvals/configuration/deployment-yaml.md
+++ b/docs/approvals/configuration/deployment-yaml.md
@@ -1,0 +1,40 @@
+# Deployment YAML reference
+
+When `gdeploy init` is run, a `granted-deployment.yml` file is created in the folder that the command was executed in. This YAML file contains the parameters for your Granted Approvals deployment. It includes information about where the deployment is running, such as the AWS account ID and region, as well as the configured identity provider and Access Providers.
+
+You can edit the YAML file manually using a text editor of choice. Some `gdeploy` commands will make changes to the YAML file automatically, such as `gdeploy release set <release version>`. When `gdeploy` makes automatic changes to the YAML file, any comments in the YAML (like `# example comment`) are removed.
+
+Here's an example of a complete `granted-deployment.yml` for reference:
+
+```yaml
+version: 2
+deployment:
+  stackName: Granted
+  account: "123456789012"
+  region: us-west-2
+  release: 0.4.3
+  parameters:
+    CognitoDomainPrefix: granted-login-mycompany
+    AdministratorGroupID: 00g6cyy2ha8VTk3mK5d7
+    DeploymentSuffix: <only required if there are multiple Granted CloudFormation stacks deployed to the same AWS account>
+    IdentityProviderType: okta
+    SamlSSOMetadataURL: https://mycompany.okta.com/app/abcdef12345/sso/saml/metadata
+    FrontendDomain: granted.mycompany.com
+    FrontendCertificateARN: arn:aws:acm:us-east-1:123456789012:certificate/12345-12345-12345-12345-12345
+    APIGatewayWAFACLARN: arn:aws:wafv2:us-west-2:123456789012:regional/webacl/acl-name/d34e51bd-df7f-41a3-93d1-4735efb5af4c
+    CloudfrontWAFACLARN: arn:aws:wafv2:us-east-1:123456789012:global/webacl/cloudfront-acl-name/ebdf717e-7d52-458f-ab78-caa45b2d7b57
+    ProviderConfiguration:
+      aws-sso:
+        uses: commonfate/aws-sso@v2
+        with:
+          identityStoreId: d-12345abc
+          instanceArn: arn:aws:sso:::instance/ssoins-1234512345
+          region: ap-southeast-2
+    IdentityConfiguration:
+      okta:
+        apiToken: awsssm:///granted/secrets/identity/okta/token:1
+        orgUrl: https://mycompany.okta.com
+    NotificationsConfiguration:
+      slack:
+        apiToken: awsssm:///granted/secrets/notifications/slack/token:1
+```

--- a/docs/approvals/configuration/waf.md
+++ b/docs/approvals/configuration/waf.md
@@ -68,6 +68,12 @@ Update your deployment to apply the changes:
 gdeploy update
 ```
 
+You should see an output similar to the below:
+
+```
+[✔] Your Granted deployment has been updated
+```
+
 Now visit the web dashboard with `gdeploy dashboard open`. You should be denied access to the dashboard in your browser and see an empty page.
 
 ![Screenshot of web browser with an empty page](/img/waf/blocked.png)
@@ -93,6 +99,12 @@ Update your deployment to apply the changes:
 
 ```
 gdeploy update
+```
+
+You should see an output similar to the below:
+
+```
+[✔] Your Granted deployment has been updated
 ```
 
 Clean up the Web ACLs using the AWS CLI by running the commands below in the same folder as your `granted-deployment.yml` file.
@@ -136,4 +148,10 @@ Update your deployment to apply the changes:
 
 ```
 gdeploy update
+```
+
+You should see an output similar to the below:
+
+```
+[✔] Your Granted deployment has been updated
 ```

--- a/docs/approvals/configuration/waf.md
+++ b/docs/approvals/configuration/waf.md
@@ -1,0 +1,139 @@
+# Web Application Firewall (WAF) integration
+
+Granted Approvals can integrate with [AWS WAF](https://aws.amazon.com/waf/) to allow additional network protection in front of the web dashboard and API.
+
+AWS WAF uses [Web access control lists (ACLs)](https://docs.aws.amazon.com/waf/latest/developerguide/web-acl.html) to define rules against HTTPS requests. ACLs allow you to block or display a [CAPTCHA](https://en.wikipedia.org/wiki/CAPTCHA) based on policies that you define.
+
+## Getting started
+
+This guide will walk through creating WAF Web ACLs and connecting them to a Granted Approvals deployment. It will take around 10 minutes to complete, and you'll need access to a role with permission to create WAF Web ACLs in the AWS account that Granted Approvals is running in.
+
+:::info
+There is no free tier for WAF Web ACLs. If left running, the rules created in this guide will cost around $12 per month. Make sure to delete the Web ACLs after you've finished testing Granted Approvals if you're evaluating the deployment in a personal AWS account.
+:::
+
+Granted Approvals has support for WAF Web ACLs to protect the following components:
+
+| Component      | Description                                                       | Scope                                                                                      |
+| -------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| CloudFront CDN | Static HTML/JavaScript web application for user-facing dashboards | `CLOUDFRONT` (must be deployed to `us-east-1`)                                             |
+| API Gateway    | User facing API                                                   | `REGIONAL` (must be deployed to the same region your Granted Approvals deployment runs in) |
+
+Let's start by creating WAF Web ACLs. We'll use the AWS CLI to create these, but you can use the AWS console or infrastructure-as-code like Terraform too. To show how the WAF integration works, we'll create rules which block all access to Granted Approvals. Open a new terminal window in the folder that your `granted-deployment.yml` is in, and run the following commands:
+
+```bash
+# make sure you have assumed a role which allows access to create Web ACLs in the AWS account that Granted Approvals is running in
+
+GRANTED_AWS_REGION=$(gdeploy output Region)
+
+# create the Web ACL for the API
+aws wafv2 create-web-acl --name granted-test-api-acl --scope REGIONAL --region=$GRANTED_AWS_REGION --default-action Block={} --description "test WAF ACL for Granted Approvals" --visibility-config SampledRequestsEnabled=false,CloudWatchMetricsEnabled=false,MetricName=granted-test-api-acl
+
+# create the Web ACL for the CloudFront CDN
+aws wafv2 create-web-acl --name granted-test-cdn-acl --scope CLOUDFRONT --region=us-east-1 --default-action Block={} --description "test WAF ACL for Granted Approvals" --visibility-config SampledRequestsEnabled=false,CloudWatchMetricsEnabled=false,MetricName=granted-test-cdn-acl
+```
+
+When creating the ACLs, you should see an output like the following:
+
+```
+{
+    "Summary": {
+        "Name": "granted-test-cdn-acl",
+        "Id": "621ccb45-b0ec-4312-91a4-7a8760122f02",
+        "Description": "test WAF ACL for Granted Approvals",
+        "LockToken": "299cceae-4dcd-48c4-a215-8b6199d9536f",
+        "ARN": "arn:aws:wafv2:us-east-1:123456789012:global/webacl/granted-test-cdn-acl/621ccb45-b0ec-4312-91a4-7a8760122f02"
+    }
+}
+```
+
+We need to link our WAF ACLs with our Granted Approvals deployment. To do this, open `granted-deployment.yml` in a text editor and add the `APIGatewayWAFACLARN` and `CloudfrontWAFACLARN` parameters:
+
+```diff
+deployment:
+  stackName: Granted
+  account: "123456789012"
+  region: us-west-2
+  release: 0.4.3
+  parameters:
++    APIGatewayWAFACLARN: arn:aws:wafv2:us-west-2:123456789012:regional/webacl/acl-name/d34e51bd-df7f-41a3-93d1-4735efb5af4c
++    CloudfrontWAFACLARN: arn:aws:wafv2:us-east-1:123456789012:global/webacl/cloudfront-acl-name/ebdf717e-7d52-458f-ab78-caa45b2d7b57
+```
+
+The `APIGatewayWAFACLARN` should be the ARN of the first ACL that we deployed. It must have `:regional/` as part of its ARN. The `CloudfrontWAFACLARN` should be the ARN of the second ACL, and must have `:global/` as part of its ARN.
+
+Update your deployment to apply the changes:
+
+```
+gdeploy update
+```
+
+Now visit the web dashboard with `gdeploy dashboard open`. You should be denied access to the dashboard in your browser and see an empty page.
+
+![Screenshot of web browser with an empty page](/img/waf/blocked.png)
+
+Blocking all traffic to Granted Approvals isn't very helpful though. You can [customise the Web ACLs](https://docs.aws.amazon.com/waf/latest/developerguide/web-acl.html) and write your own policies based on IP addresses, regexes, and detection of malicious scripting. Alternatively, you can use [managed rule groups](https://docs.aws.amazon.com/waf/latest/developerguide/waf-managed-rule-groups.html), which are rules managed by AWS or other third-party vendors.
+
+## Cleaning up
+
+To clean up the test Web ACLs that were deployed, first unlink them from your Granted Approvals deployment. Remove the following entries from your `granted-deployment.yml` file:
+
+```diff
+deployment:
+  stackName: Granted
+  account: "123456789012"
+  region: us-west-2
+  release: 0.4.3
+  parameters:
+-    APIGatewayWAFACLARN: arn:aws:wafv2:us-west-2:123456789012:regional/webacl/acl-name/d34e51bd-df7f-41a3-93d1-4735efb5af4c
+-    CloudfrontWAFACLARN: arn:aws:wafv2:us-east-1:123456789012:global/webacl/cloudfront-acl-name/ebdf717e-7d52-458f-ab78-caa45b2d7b57
+```
+
+Update your deployment to apply the changes:
+
+```
+gdeploy update
+```
+
+Clean up the Web ACLs using the AWS CLI by running the commands below in the same folder as your `granted-deployment.yml` file.
+
+```bash
+GRANTED_AWS_REGION=$(gdeploy output Region)
+
+# find the Id and LockToken of the CloudFront Web ACL
+CDN_ACL_ID=$(aws wafv2 list-web-acls --scope CLOUDFRONT --region us-east-1 --query 'WebACLs[?Name==`granted-test-cdn-acl`] | [0].Id' --output text)
+CDN_ACL_LOCKTOKEN=$(aws wafv2 list-web-acls --scope CLOUDFRONT --region us-east-1 --query 'WebACLs[?Name==`granted-test-cdn-acl`] | [0].LockToken' --output text)
+
+# find the Id and LockToken of the API ACL
+API_ACL_ID=$(aws wafv2 list-web-acls --scope REGIONAL --region $GRANTED_AWS_REGION --query 'WebACLs[?Name==`granted-test-api-acl`] | [0].Id' --output text)
+API_ACL_LOCKTOKEN=$(aws wafv2 list-web-acls --scope REGIONAL --region $GRANTED_AWS_REGION --query 'WebACLs[?Name==`granted-test-api-acl`] | [0].LockToken' --output text)
+
+# delete the CloudFront ACL
+aws wafv2 delete-web-acl --region us-east-1 --scope CLOUDFRONT --name granted-test-api-acl --id $CDN_ACL_ID --lock-token $CDN_ACL_LOCKTOKEN
+
+# delete the API ACL
+aws wafv2 delete-web-acl --region $GRANTED_AWS_REGION --scope REGIONAL --name granted-test-api-acl --id $API_ACL_ID --lock-token $API_ACL_LOCKTOKEN
+```
+
+## With existing WAF ACLs
+
+For production deployments of Granted Approvals, we recommend using infrastructure-as-code such as Terraform or CloudFormation to provision your WAF ACLs.
+
+After your WAF ACLs have been provisioned, open `granted-deployment.yml` in a text editor and add the `APIGatewayWAFACLARN` and `CloudfrontWAFACLARN` parameters:
+
+```diff
+deployment:
+  stackName: Granted
+  account: "123456789012"
+  region: us-west-2
+  release: 0.4.3
+  parameters:
++    APIGatewayWAFACLARN: arn:aws:wafv2:us-west-2:123456789012:regional/webacl/acl-name/d34e51bd-df7f-41a3-93d1-4735efb5af4c
++    CloudfrontWAFACLARN: arn:aws:wafv2:us-east-1:123456789012:global/webacl/cloudfront-acl-name/ebdf717e-7d52-458f-ab78-caa45b2d7b57
+```
+
+Update your deployment to apply the changes:
+
+```
+gdeploy update
+```

--- a/static/img/waf/blocked.png
+++ b/static/img/waf/blocked.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa6d729d70b14c541a3d048259240d87fb4be82ee48742e22343e4c23e666b71
+size 390197


### PR DESCRIPTION
Adds docs for configuring WAF ACLs and linking them to a Granted Approvals deployment, to be included in our v0.6.3 release.