### PR TITLE
rename 'requirements' to 'install the AWS CLI'

### DIFF
--- a/docs/granted/getting-started.mdx
+++ b/docs/granted/getting-started.mdx
@@ -11,7 +11,7 @@ This guide will get you started using Granted to assume roles in AWS. It will ta
 
 ![A screenshot of Granted CLI showing a selection menu for AWS profiles](/img/cli-screenshot.png)
 
-## Requirements
+## Install the AWS CLI
 
 Although Granted doesn't depend on the AWS CLI, we recommend [installing it](https://docs.aws.amazon.com/cli/latest/userguide/deploying-granted-install.html) in order to run a test command to verify Granted is working properly.
 


### PR DESCRIPTION
We've received some user feedback that it appears 'aws sso configure' is a required step, even though it's not necessary to start using the Granted CLI (particularly if you are using `assume --sso ...`)