### PR TITLE
docs: Document setting icon and color on profiles

### DIFF
--- a/docs/granted/configuration.md
+++ b/docs/granted/configuration.md
@@ -95,6 +95,27 @@ You will get a response like this:
 
 Select which browser you would like to use and press Enter.
 
+## Setting color and icon preferences for profiles
+
+If you use Firefox with the [Granted Firefox Addon](https://addons.mozilla.org/en-GB/firefox/addon/granted/), you can set the color and icon preference for each profile.  This is useful for distinguishing between profiles at a glance.
+
+To customize the color and icon add `granted_color` and `granted_icon` to the profile in your `~/.aws/config` file.
+
+This configuration:
+
+```
+granted_color = green
+granted_icon = dollar
+```
+
+Will result in this:
+
+![A screenshot of the Firefox address bar, showing a custom color and icon for a profile](/img/granted-firefox-custom-color-icon.png)
+
+Valid colors are: `blue`, `turquoise`, `green`, `yellow`, `orange`, `red`, `pink` and `purple`
+
+Valid icons are: `fingerprint`, `briefcase`, `dollar`, `cart`, `circle`, `gift`, `vacation`, `food`, `fruit`, `pet`, `tree` and `chill`
+
 ## Custom browser for running SSO flows
 
 You can specify a custom browser path for your SSO login flows with Granted.

--- a/static/img/granted-firefox-custom-color-icon.png
+++ b/static/img/granted-firefox-custom-color-icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60152d6853456e4bc1622589b7c55d1aeb36de682b0a378752e1cdd8bf12448f
+size 24960


### PR DESCRIPTION
## Describe your changes

Document how to set a custom icon and color for a profile in Granted

## Type of change

- [x] New feature documentation (non-breaking change which adds functionality)

## Issue and Documentation

[Slack thread](https://commonfatecommunity.slack.com/archives/C0356DGLXME/p1677205468550529)

## Testing

Pull and run `yarn start`

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have linked the feature PR if relevant.
- [ ] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
