### PR TITLE
Added docs for auto login and duration flag

### DIFF
--- a/docs/granted/recipes/access-requests.md
+++ b/docs/granted/recipes/access-requests.md
@@ -52,4 +52,8 @@ Additionally you can run:
 granted exp request aws
 ```
 
-to request access to roles through Common Fate.
+to request access to roles through Common Fate. If you would like to set the duration for the request, you can add the `--duration` flag to the command:
+
+```
+granted exp request aws --duration 2h
+```

--- a/docs/granted/recipes/credential-process.md
+++ b/docs/granted/recipes/credential-process.md
@@ -39,6 +39,12 @@ You should see something like
     "Arn": "<Arn>",
 }
 ```
+## Auto-login with Credential Process
+You can enable auto login with `credential_process` by using the `--auto-login` flag:
+```
+credential_process = granted credential-process --auto-login --profile my-profile
+```
+(Credits to [Eric Miller](https://github.com/sosheskaz) for implementing the auto login flag)
 
 :::info
 Additionally, if you would like to use Common Fate for turn-key access requests, we support a further integration in the recipe, [Connecting to Common Fate](/granted/recipes/access-requests).


### PR DESCRIPTION
Added docs on the `--auto-login` flag in `credential-process` and  the `--duration flag` in `granted exp request aws`