### PR TITLE
Add recipe to configure gnome-keyring using the default login keychain

### DIFF
--- a/docs/granted/recipes/ubuntu-keyring.md
+++ b/docs/granted/recipes/ubuntu-keyring.md
@@ -1,0 +1,23 @@
+# Encrypting AWS SSO Tokens Using Gnome Keyring
+
+Granted uses an [open-source library](https://github.com/99designs/keyring) to securely store AWS SSO tokens in a backend service. Apart from `pass` or the `Windows Credentials Manager`, Linux Desktop users that leverage Gnome as their desktop environment can use keyring to securely store AWS SSO tokens, and get it unlocked with the default `login` keychain.
+
+## Prerequisites
+
+- Installed Granted CLI tool.
+- Access to AWS SSO tokens.
+- Gnome keyring installed. Tested on Ubuntu 22 with Gnome 40+
+
+## Configuration
+
+Open the Granted configuration file located at `~/.granted/config`. Add the following configuration to specify the backend for keyring:
+
+```
+[Keyring]
+  Backend = "secret-service"
+  LibSecretCollectionName = "login"
+```
+
+Next time you run Granted, it will use the `secret-service` backend to store AWS SSO tokens and it will not ask you to enter your password. It will unlock it with the `login` keychain instead.
+
+As of Granted `v0.22.2` there is no official documentation on how to configure the keyring, however, [these settings](https://github.com/common-fate/granted/blob/bcf79899f282cceff6313f1757d963e4dbbf44e1/pkg/config/config.go#L58-L63) are already exposed and can be used. Refer to the upstream [library documentation](https://pkg.go.dev/github.com/99designs/keyring?utm_source=godoc) for further details.


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Linux desktop users that use Gnome and want to rely on their `login` keychain for encrypting their AWS SSO tokens, can configure granted through some upstream settings that are not documented elsewhere.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature documentation (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Issue and Documentation

<!-- Please link the appropriate Linear/GitHub issues as well as any supporting documentation or video explainers. Also include a link to the feature PR if relevant. -->

See https://commonfatecommunity.slack.com/archives/C0356DGLXME/p1699023804724609

## Testing

<!-- If testing requires instructions different to that in the [`README.md`](http://README.md) please describe how the reviewer can test the changes. Also include steps to reproduce the testing environment. -->

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have linked the feature PR if relevant.
- [ ] New and existing unit tests pass with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
