### PR TITLE
bumped version number to 2.27.1

### DIFF
--- a/src/content/docs/config/terraform.mdx
+++ b/src/content/docs/config/terraform.mdx
@@ -48,7 +48,7 @@ terraform {
   required_providers {
     commonfate = {
       source  = "common-fate/commonfate"
-      version = "2.13.0"
+      version = "2.27.1"
     }
   }
 }
@@ -71,7 +71,7 @@ terraform {
   required_providers {
     commonfate = {
       source  = "common-fate/commonfate"
-      version = "2.13.0"
+      version = "2.27.1"
     }
   }
 }


### PR DESCRIPTION
Bumped version number to 2.27.1 so "try_extend_after_seconds" field error will not appear for customers who are using the example block from the website.