### PR TITLE
docs: fix homebrew installation command for granted due to name clash

### DIFF
--- a/src/content/docs/granted/getting-started.mdx
+++ b/src/content/docs/granted/getting-started.mdx
@@ -72,8 +72,7 @@ In order to use Granted you'll need to install it on your system. Common Fate pr
     [Homebrew](https://brew.sh/) is an open source package manager for MacOS. We publish a Homebrew formula for Granted. To install Granted with Homebrew, run the commands below in your terminal.
 
     ```bash
-    brew tap common-fate/granted
-    brew install granted
+    brew install common-fate/granted/granted
     ```
     ### Manual install
     Select the steps which match your system architecture. You can find your architecture by running `uname -m` from a terminal window.


### PR DESCRIPTION
## Changes

Fixes #35

